### PR TITLE
Update homepage.pug

### DIFF
--- a/views/homepage.pug
+++ b/views/homepage.pug
@@ -27,7 +27,7 @@ block content
         div(id="middle-section")
             ul(class='task-index')
                 if listHeader
-                    h1= listHeader
+                    h1#summary-header= listHeader
                 else 
                     h1(id="summary-header") All Tasks
                 //- li#task-list-header Type in a task.


### PR DESCRIPTION
replacing this code on line 30 of homepage.pug will allow the Lists to show up in the middle section when you click on them. Currently only "All list" shows up in the middle section. When you click on another list, the header disappears